### PR TITLE
Remove duplicate entry in playstation config

### DIFF
--- a/data/conf/playstation.dnsmasq.conf
+++ b/data/conf/playstation.dnsmasq.conf
@@ -4,4 +4,3 @@ address=/pls.patch.station.sony.com/NGINX_IP
 address=/gs2.sonycoment.loris-e.llnwd.net/NGINX_IP
 address=/.update.playstation.net/NGINX_IP
 address=/gs2.ww.prod.dl.playstation.net/NGINX_IP
-address=/gs2.sonycoment.loris-e.llnwd.net/NGINX_IP

--- a/data/conf/playstation.nginx.conf
+++ b/data/conf/playstation.nginx.conf
@@ -8,8 +8,7 @@ server {
 		pls.patch.station.sony.com
 		gs2.sonycoment.loris-e.llnwd.net
 		.update.playstation.net
-		gs2.ww.prod.dl.playstation.net
-		gs2.sonycoment.loris-e.llnwd.net;
+		gs2.ww.prod.dl.playstation.net;
 
 	access_log /var/log/nginx/playstation-access.log;
 	error_log /var/log/nginx/playstation-error.log error;


### PR DESCRIPTION
Removes the following from error logs
2017/12/02 16:17:08 [warn] 1#1: conflicting server name "gs2.sonycoment.loris-e.llnwd.net" on 0.0.0.0:80, ignored