### PR TITLE
Bugfix/ip auto detect regex improvement

### DIFF
--- a/docker-dnsmasq/start-dnsmasq.sh
+++ b/docker-dnsmasq/start-dnsmasq.sh
@@ -2,7 +2,7 @@
 
 get_ip() {
   interface=$(route | grep default | awk '{print $(NF)}')
-  ip route show dev $interface | grep -Pom1 'link\s+src\s+\d+\.\d+\.\d+\.\d+' | awk -F " " '{print $NF}'
+  ip route show dev $interface | grep -Eom1 'link[[:space:]]+src[[:space:]]+[0-9.]+' | awk -F " " '{print $NF}'
 }
 
 if [[ -z $HOST_IP ]]; then

--- a/docker-dnsmasq/start-dnsmasq.sh
+++ b/docker-dnsmasq/start-dnsmasq.sh
@@ -2,7 +2,7 @@
 
 get_ip() {
   interface=$(route | grep default | awk '{print $(NF)}')
-  ip route show dev $interface| grep -w "link" | awk -F " " '{print $NF}'
+  ip route show dev $interface | grep -Pom1 'link\s+src\s+\d+\.\d+\.\d+\.\d+' | awk -F " " '{print $NF}'
 }
 
 if [[ -z $HOST_IP ]]; then


### PR DESCRIPTION
Fixes a bug where differences in the `ip route` output can cause auto detection to fail. See more information in issue #15 